### PR TITLE
Fix for error - Cannot set property 'reporterOptions' of undefined

### DIFF
--- a/index.js
+++ b/index.js
@@ -33,7 +33,7 @@ function notify(stats, runner) {
 
 // hacky way of getting the other reporter.. :P
 function getReporter(reporter) {
-	var temp = {};
+	var temp = {options:{}};
 	Mocha.prototype.reporter.call(temp, reporter);
 	return temp._reporter;
 }


### PR DESCRIPTION
Adding a fix for an error which occurs when using the decorate method.

Mocha is expecting an options property to exist, so an empty "options" object has
been added to the "temp" object to stand in for this.

fixes #1 
