### PR TITLE
Decorate works with --watch

### DIFF
--- a/index.js
+++ b/index.js
@@ -61,9 +61,9 @@ NotifyReporter.message_fail = '%(failures)d of %(total)d tests failed';
 
 // Tries to decorate other reporter with notifications
 // Borrows Mochas reporter method
-NotifyReporter.decorate = function(reporter) {
+NotifyReporter.decorate = function(name) {
 	return function(runner) {
-		reporter = new (getReporter(reporter))(runner);
+		var reporter = new (getReporter(name))(runner);
 		runner.on('end', function() {
 			notify(reporter.stats, runner);
 		});


### PR DESCRIPTION
This fixes a bug where a parameter mutation in `decorate` causes an error when used with `mocha --watch`. It works on the initial run, but fails when a file is saved:

```
"[object Object]" reporter blew up with error:
AssertionError: path must be a string
    at Module.require (module.js:366:3)
    at require (internal/module.js:16:19)
    at Object.Mocha.reporter (C:\Users\Scott\Documents\git\indica\halo-web\node_modules\mocha\lib\mocha.js:151:21)
    at getReporter (C:\Users\Scott\Documents\git\indica\halo-web\node_modules\mocha-notifier-reporter\index.js:37:27)
    at new <anonymous> (C:\Users\Scott\Documents\git\indica\halo-web\node_modules\mocha-notifier-reporter\index.js:66:19)
    at Mocha.run (C:\Users\Scott\Documents\git\indica\halo-web\node_modules\mocha\lib\mocha.js:475:18)
    at loadAndRun (C:\Users\Scott\Documents\git\indica\halo-web\node_modules\mocha\bin\_mocha:360:22)
    at rerun (C:\Users\Scott\Documents\git\indica\halo-web\node_modules\mocha\bin\_mocha:387:5)
    at C:\Users\Scott\Documents\git\indica\halo-web\node_modules\mocha\bin\_mocha:395:7
    at StatWatcher.<anonymous> (C:\Users\Scott\Documents\git\indica\halo-web\node_modules\mocha\lib\utils.js:174:9)
    at emitTwo (events.js:100:13)
    at StatWatcher.emit (events.js:185:7)
    at StatWatcher._handle.onchange (fs.js:1369:10)
Error: invalid reporter "[object Object]"
    at Object.Mocha.reporter (C:\Users\Scott\Documents\git\indica\halo-web\node_modules\mocha\lib\mocha.js:164:13)
    at getReporter (C:\Users\Scott\Documents\git\indica\halo-web\node_modules\mocha-notifier-reporter\index.js:37:27)
    at new <anonymous> (C:\Users\Scott\Documents\git\indica\halo-web\node_modules\mocha-notifier-reporter\index.js:66:19)
    at Mocha.run (C:\Users\Scott\Documents\git\indica\halo-web\node_modules\mocha\lib\mocha.js:475:18)
    at loadAndRun (C:\Users\Scott\Documents\git\indica\halo-web\node_modules\mocha\bin\_mocha:360:22)
    at rerun (C:\Users\Scott\Documents\git\indica\halo-web\node_modules\mocha\bin\_mocha:387:5)
    at C:\Users\Scott\Documents\git\indica\halo-web\node_modules\mocha\bin\_mocha:395:7
    at StatWatcher.<anonymous> (C:\Users\Scott\Documents\git\indica\halo-web\node_modules\mocha\lib\utils.js:174:9)
    at emitTwo (events.js:100:13)
    at StatWatcher.emit (events.js:185:7)
    at StatWatcher._handle.onchange (fs.js:1369:10)
```
